### PR TITLE
omit unecessary fields from API calls that might break the UI

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -113,6 +113,7 @@ func testServiceRecords(c client.Client, vehicleId int64) {
 		Date:        time.Now(),
 		Description: "description",
 		Notes:       "test note",
+		Cost:        25.99,
 	}
 	err := new.Add(ctx, c, vehicleId)
 	if err != nil {
@@ -153,6 +154,7 @@ func testRepairRecords(c client.Client, vehicleId int64) {
 		Date:        time.Now(),
 		Description: "description",
 		Notes:       "test note",
+		Cost:        31.99,
 	}
 	err := new.Add(ctx, c, vehicleId)
 	if err != nil {
@@ -193,6 +195,7 @@ func testUpgradeRecords(c client.Client, vehicleId int64) {
 		Date:        time.Now(),
 		Description: "description",
 		Notes:       "test note",
+		Cost:        55.44,
 	}
 	err := new.Add(ctx, c, vehicleId)
 	if err != nil {
@@ -232,6 +235,7 @@ func testTaxRecords(c client.Client, vehicleId int64) {
 		Date:        time.Now(),
 		Description: "description",
 		Notes:       "test note",
+		Cost:        99.00,
 	}
 	err := new.Add(ctx, c, vehicleId)
 	if err != nil {
@@ -271,6 +275,7 @@ func testGasRecords(c client.Client, vehicleId int64) {
 		Odometer:     999000,
 		FuelConsumed: 7,
 		IsFillToFull: true,
+		MissedFuelUp: true,
 		Cost:         15,
 		Date:         time.Now(),
 		Description:  "description",

--- a/gasrecords/structs.go
+++ b/gasrecords/structs.go
@@ -8,18 +8,18 @@ import (
 
 type GasRecord struct {
 	ID           int64     `json:"id,omitempty"`
-	Date         time.Time `json:"date"`
-	Odometer     int64     `json:"odometer"`
-	FuelConsumed float64   `json:"fuelConsumed"`
-	FuelEconomy  float64   `json:"fuelEconomy"`
+	Date         time.Time `json:"date,omitempty"`
+	Odometer     int64     `json:"odometer,omitempty"`
+	FuelConsumed float64   `json:"fuelConsumed,omitempty"`
+	FuelEconomy  float64   `json:"fuelEconomy,omitempty"`
 	IsFillToFull bool      `json:"isFillToFull"`
 	MissedFuelUp bool      `json:"missedFuelUp"`
-	Description  string    `json:"description"`
-	Notes        string    `json:"notes"`
-	Cost         float64   `json:"cost"`
-	Tags         string    `json:"tags"`
-	ExtraFields  []string  `json:"extraFields"`
-	Files        []string  `json:"files"`
+	Description  string    `json:"description,omitempty"`
+	Notes        string    `json:"notes,omitempty"`
+	Cost         float64   `json:"cost,omitempty"`
+	Tags         string    `json:"tags,omitempty"`
+	ExtraFields  []string  `json:"extraFields,omitempty"`
+	Files        []string  `json:"files,omitempty"`
 }
 
 func convertSingle(in map[string]interface{}) GasRecord {

--- a/reminders/struct.go
+++ b/reminders/struct.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Reminder struct {
-	Description string    `json:"description"`
-	Urgency     string    `json:"urgency"`
-	Metric      string    `json:"metric"`
-	Notes       string    `json:"notes"`
-	DueDate     time.Time `json:"dueDate"`
-	DueOdometer int64     `json:"dueOdometer"`
+	Description string    `json:"description,omitempty"`
+	Urgency     string    `json:"urgency,omitempty"`
+	Metric      string    `json:"metric,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
+	DueDate     time.Time `json:"dueDate,omitempty"`
+	DueOdometer int64     `json:"dueOdometer,omitempty"`
 }
 
 func ConvertSingle(x interface{}) Reminder {

--- a/repairrecords/structs.go
+++ b/repairrecords/structs.go
@@ -8,14 +8,14 @@ import (
 
 type RepairRecord struct {
 	ID          int64     `json:"id,omitempty"`
-	Date        time.Time `json:"date"`
-	Odometer    int64     `json:"odometer"`
-	Description string    `json:"description"`
-	Notes       string    `json:"notes"`
-	Cost        float64   `json:"cost"`
-	Tags        string    `json:"tags"`
-	ExtraFields []string  `json:"extraFields"`
-	Files       []string  `json:"files"`
+	Date        time.Time `json:"date,omitempty"`
+	Odometer    int64     `json:"odometer,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
+	Cost        float64   `json:"cost,omitempty"`
+	Tags        string    `json:"tags,omitempty"`
+	ExtraFields []string  `json:"extraFields,omitempty"`
+	Files       []string  `json:"files,omitempty"`
 }
 
 func convertSingle(in map[string]interface{}) RepairRecord {

--- a/servicerecord/structs.go
+++ b/servicerecord/structs.go
@@ -8,14 +8,14 @@ import (
 
 type ServiceRecord struct {
 	ID          int64     `json:"id,omitempty"`
-	Date        time.Time `json:"date"`
-	Odometer    int64     `json:"odometer"`
-	Description string    `json:"description"`
-	Notes       string    `json:"notes"`
-	Cost        float64   `json:"cost"`
-	Tags        string    `json:"tags"`
-	ExtraFields []string  `json:"extraFields"`
-	Files       []string  `json:"files"`
+	Date        time.Time `json:"date,omitempty"`
+	Odometer    int64     `json:"odometer,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
+	Cost        float64   `json:"cost,omitempty"`
+	Tags        string    `json:"tags,omitempty"`
+	ExtraFields []string  `json:"extraFields,omitempty"`
+	Files       []string  `json:"files,omitempty"`
 }
 
 func convertSingle(in map[string]interface{}) ServiceRecord {

--- a/taxrecords/structs.go
+++ b/taxrecords/structs.go
@@ -7,14 +7,14 @@ import (
 )
 
 type TaxRecord struct {
-	ID          int64     `json:"id,omitempty"`
-	Date        time.Time `json:"date"`
-	Description string    `json:"description"`
-	Notes       string    `json:"notes"`
-	Cost        float64   `json:"cost"`
-	Tags        string    `json:"tags"`
-	ExtraFields []string  `json:"extraFields"`
-	Files       []string  `json:"files"`
+	ID          int64     `json:"id,omitempty,omitempty"`
+	Date        time.Time `json:"date,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
+	Cost        float64   `json:"cost,omitempty"`
+	Tags        string    `json:"tags,omitempty"`
+	ExtraFields []string  `json:"extraFields,omitempty"`
+	Files       []string  `json:"files,omitempty"`
 }
 
 func convertSingle(in map[string]interface{}) TaxRecord {

--- a/upgraderecords/structs.go
+++ b/upgraderecords/structs.go
@@ -8,14 +8,14 @@ import (
 
 type UpgradeRecord struct {
 	ID          int64     `json:"id,omitempty"`
-	Date        time.Time `json:"date"`
-	Odometer    int64     `json:"odometer"`
-	Description string    `json:"description"`
-	Notes       string    `json:"notes"`
-	Cost        float64   `json:"cost"`
-	Tags        string    `json:"tags"`
-	ExtraFields []string  `json:"extraFields"`
-	Files       []string  `json:"files"`
+	Date        time.Time `json:"date,omitempty"`
+	Odometer    int64     `json:"odometer,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Notes       string    `json:"notes,omitempty"`
+	Cost        float64   `json:"cost,omitempty"`
+	Tags        string    `json:"tags,omitempty"`
+	ExtraFields []string  `json:"extraFields,omitempty"`
+	Files       []string  `json:"files,omitempty"`
 }
 
 func convertSingle(in map[string]interface{}) UpgradeRecord {

--- a/vehicleinfo/structs.go
+++ b/vehicleinfo/structs.go
@@ -7,27 +7,27 @@ import (
 )
 
 type VehicleInfo struct {
-	VehicleData               vehicles.VehicleData `json:"vehicleData"`
-	VeryUrgentReminderCount   int64                `json:"veryUrgentReminderCount"`
-	UrgentReminderCount       int64                `json:"urgentReminderCount"`
-	NotUrgentReminderCount    int64                `json:"notUrgentReminderCount"`
-	PastDueReminderCount      int64                `json:"pastDueReminderCount"`
-	NextReminder              reminders.Reminder   `json:"nextReminder"`
-	ServiceRecordCount        int64                `json:"serviceRecordCount"`
-	ServiceRecordCost         float64              `json:"serviceRecordCost"`
-	RepairRecordCount         int64                `json:"repairRecordCount"`
-	RepairRecordCost          float64              `json:"repairRecordCost"`
-	UpgradeRecordCount        int64                `json:"upgradeRecordCount"`
-	UpgradeRecordCost         float64              `json:"upgradeRecordCost"`
-	TaxRecordCount            int64                `json:"taxRecordCount"`
-	TaxRecordCost             float64              `json:"taxRecordCost"`
-	GasRecordCount            int64                `json:"gasRecordCount"`
-	GasRecordCost             float64              `json:"gasRecordCost"`
-	LastReportedOdometer      int64                `json:"lastReportedOdometer"`
-	PlanRecordBackLogCount    int64                `json:"planRecordBackLogCount"`
-	PlanRecordInProgressCount int64                `json:"planRecordInProgressCount"`
-	PlanRecordTestingCount    int64                `json:"planRecordTestingCount"`
-	PlanRecordDoneCount       int64                `json:"planRecordDoneCount"`
+	VehicleData               vehicles.VehicleData `json:"vehicleData,omitempty"`
+	VeryUrgentReminderCount   int64                `json:"veryUrgentReminderCount,omitempty"`
+	UrgentReminderCount       int64                `json:"urgentReminderCount,omitempty"`
+	NotUrgentReminderCount    int64                `json:"notUrgentReminderCount,omitempty"`
+	PastDueReminderCount      int64                `json:"pastDueReminderCount,omitempty"`
+	NextReminder              reminders.Reminder   `json:"nextReminder,omitempty"`
+	ServiceRecordCount        int64                `json:"serviceRecordCount,omitempty"`
+	ServiceRecordCost         float64              `json:"serviceRecordCost,omitempty"`
+	RepairRecordCount         int64                `json:"repairRecordCount,omitempty"`
+	RepairRecordCost          float64              `json:"repairRecordCost,omitempty"`
+	UpgradeRecordCount        int64                `json:"upgradeRecordCount,omitempty"`
+	UpgradeRecordCost         float64              `json:"upgradeRecordCost,omitempty"`
+	TaxRecordCount            int64                `json:"taxRecordCount,omitempty"`
+	TaxRecordCost             float64              `json:"taxRecordCost,omitempty"`
+	GasRecordCount            int64                `json:"gasRecordCount,omitempty"`
+	GasRecordCost             float64              `json:"gasRecordCost,omitempty"`
+	LastReportedOdometer      int64                `json:"lastReportedOdometer,omitempty"`
+	PlanRecordBackLogCount    int64                `json:"planRecordBackLogCount,omitempty"`
+	PlanRecordInProgressCount int64                `json:"planRecordInProgressCount,omitempty"`
+	PlanRecordTestingCount    int64                `json:"planRecordTestingCount,omitempty"`
+	PlanRecordDoneCount       int64                `json:"planRecordDoneCount,omitempty"`
 }
 
 func convertSingle(in map[string]interface{}) VehicleInfo {

--- a/vehicles/structs.go
+++ b/vehicles/structs.go
@@ -7,27 +7,27 @@ import (
 )
 
 type VehicleData struct {
-	ID                    int64     `json:"id"`
-	ImageLocation         string    `json:"imageLocation"`
-	Year                  int64     `json:"year"`
-	Make                  string    `json:"make"`
-	Model                 string    `json:"model"`
-	LicensePlate          string    `json:"licensePlate"`
+	ID                    int64     `json:"id,omitempty"`
+	ImageLocation         string    `json:"imageLocation,omitempty"`
+	Year                  int64     `json:"year,omitempty"`
+	Make                  string    `json:"make,omitempty"`
+	Model                 string    `json:"model,omitempty"`
+	LicensePlate          string    `json:"licensePlate,omitempty"`
 	PurchaseDate          time.Time `json:"purchaseDate,omitempty"`
 	SoldDate              time.Time `json:"soldDate,omitempty"`
-	PurchasePrice         float64   `json:"purchasePrice"`
-	SoldPrice             float64   `json:"soldPrice"`
-	IsElectric            bool      `json:"isElectric"`
-	IsDiesel              bool      `json:"isDiesel"`
-	UseHours              bool      `json:"useHours"`
-	OdometerOptional      bool      `json:"odometerOptional"`
-	ExtraFields           []string  `json:"extraFields"`
-	Tags                  []string  `json:"tags"`
-	HasOdometerAdjustment bool      `json:"hasOdometerAdjustment"`
-	OdometerMultiplier    int64     `json:"odometerMultiplier"`
-	OdometerDifference    int64     `json:"odometerDifference"`
-	DashboardMetrics      []int64   `json:"dashboardMetrics"`
-	VehicleIdentifier     string    `json:"vehicleIdentifier"`
+	PurchasePrice         float64   `json:"purchasePrice,omitempty"`
+	SoldPrice             float64   `json:"soldPrice,omitempty"`
+	IsElectric            bool      `json:"isElectric,omitempty"`
+	IsDiesel              bool      `json:"isDiesel,omitempty"`
+	UseHours              bool      `json:"useHours,omitempty"`
+	OdometerOptional      bool      `json:"odometerOptional,omitempty"`
+	ExtraFields           []string  `json:"extraFields,omitempty"`
+	Tags                  []string  `json:"tags,omitempty"`
+	HasOdometerAdjustment bool      `json:"hasOdometerAdjustment,omitempty"`
+	OdometerMultiplier    int64     `json:"odometerMultiplier,omitempty"`
+	OdometerDifference    int64     `json:"odometerDifference,omitempty"`
+	DashboardMetrics      []int64   `json:"dashboardMetrics,omitempty"`
+	VehicleIdentifier     string    `json:"vehicleIdentifier,omitempty"`
 }
 
 func convertAll(inx []map[string]interface{}) ([]VehicleData, error) {


### PR DESCRIPTION
Lubelogger UI seems to break when sending null "files" in some API requests (like gasrecords)

omit empty uncesessary fields from JSON formation and api calls